### PR TITLE
ci: increase github token explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# dependabot triggered actions have more limited `GITHUB_TOKEN` permissions by default
+# - see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
+permissions:
+  pull-requests: write
+  statuses: write
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
dependabot-triggered actions have a more limited token scope by default