### PR TITLE
ci: include packages write permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 # dependabot triggered actions have more limited `GITHUB_TOKEN` permissions by default
 # - see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
 permissions:
+  packages: write
   pull-requests: write
   statuses: write
   checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 # - see: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
 permissions:
   packages: write
+  deployments: write
   pull-requests: write
   statuses: write
   checks: write


### PR DESCRIPTION
if dependabot authored a pr, it also acts as the actor when building and publishing in the main branch, and so needs permissions to publish to the container registry